### PR TITLE
Add Open Graph Protocol to get Facebook summary image

### DIFF
--- a/add-to-any.php
+++ b/add-to-any.php
@@ -1198,3 +1198,31 @@ function A2A_SHARE_SAVE_actlinks( $links, $file ) {
 }
 
 add_filter( 'plugin_action_links', 'A2A_SHARE_SAVE_actlinks', 10, 2 );
+
+// XTEC *********** AFEGIT Open Graph Protocol to metadata facebook share
+// 2016.10.11 @xaviernietosanchez
+
+function add_opengraph_doctype( $output ) {
+    return $output . 'xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml"';
+}
+add_filter('language_attributes', 'add_opengraph_doctype');
+
+// Add information Open Graph
+function insert_fb_in_head() {
+    global $post;
+
+    if ( ! is_singular() ) { return; } //Si no es un post o página
+
+    echo '<meta property="og:title" content="' . get_the_title() . '"/>';
+    echo '<meta property="og:type" content="article"/>';
+    echo '<meta property="og:url" content="' . get_permalink() . '"/>';
+
+    if ( has_post_thumbnail( $post->ID ) ) {
+        $thumbnail_src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'medium' );
+        echo '<meta property="og:image" content="' . esc_attr( $thumbnail_src[0] ) . '"/>';
+        echo '<img id="facebook-image" src="'.esc_attr( $thumbnail_src[0] ).'" style="display:none;"/>';
+    }
+}
+add_action( 'wp_head', 'insert_fb_in_head', 1 );
+
+//************ FI


### PR DESCRIPTION
Afegit Open Graph Protocol per tal de treure la imatge resum a l'hora de compartir per facebook.

Proves:
- Per tal de fer les proves cal fer-les o a integración (http://integracio.agora.xtec.cat/esc-migjorn/) o una vegada pujats a algún entorn. Amb al maquina virtual no resol les urls facebook.
- Cal crear un nou article, amb una imatge resum, i un text.
- Provar a compartir a facebook en la pagina del l'article.
