### PR TITLE
Add Open Graph Protocol to get Facebook summary image

### DIFF
--- a/add-to-any.php
+++ b/add-to-any.php
@@ -1100,3 +1100,25 @@ function A2A_SHARE_SAVE_actlinks( $links, $file ) {
 }
 
 add_filter( 'plugin_action_links', 'A2A_SHARE_SAVE_actlinks', 10, 2 );
+
+// XTEC *********** AFEGIT Open Graph Protocol to metadata facebook share
+// 2016.10.11 @xaviernietosanchez
+function add_opengraph_doctype( $output ) {
+    return $output . 'xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml"';
+}
+add_filter('language_attributes', 'add_opengraph_doctype');
+// Add information Open Graph
+function insert_fb_in_head() {
+    global $post;
+    if ( ! is_singular() ) { return; } //Si no es un post o página
+    echo '<meta property="og:title" content="' . get_the_title() . '"/>';
+    echo '<meta property="og:type" content="article"/>';
+    echo '<meta property="og:url" content="' . get_permalink() . '"/>';
+    if ( has_post_thumbnail( $post->ID ) ) {
+        $thumbnail_src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'medium' );
+        echo '<meta property="og:image" content="' . esc_attr( $thumbnail_src[0] ) . '"/>';
+        echo '<img id="facebook-image" src="'.esc_attr( $thumbnail_src[0] ).'" style="display:none;"/>';
+    }
+}
+add_action( 'wp_head', 'insert_fb_in_head', 1 );
+//************ FI


### PR DESCRIPTION
Afegit l'Open Graph Protocol per ajudar a facebook a fer la imatges resum i els text correctament.

A tindre en compte:
- S'ha de posar una imatge resum a l'article. Si no s'afegeix, carrega la primera imatge de la pàgina.
- La imatge no pot ser de mes alçada que amplada, perquè en aquesta cas la obvia i afegeix la primera imatge que troba.
- La primera vegada que es crea l'arxiu, i es clica a compartir (la primera vegada total, no per usuari) no surt la imatge, però si comparteixes, a facebook si que surt. Això es perquè el que fan es crear una cache a la trucada a addtoany.com i la primera vegada no la carrega (la esta creant)
- Una vegada creada aquesta cache, no importa les modificacions que facis a l'article, per que sempre surt com la primera vegada que has fet clic a compartir. Això no ho podem controlar perquè es la forma de fer de l'addtoany, es com si es guardes la url associada a unes dades (com si fos una captura)

Proves:

**Cal fer les proves en un entorn amb url accesible, no serveix la mv**
- Crear una noticia, amb fotografia resum. (tindre en compte les característiques anteriors)
- Fer clic sobre el botó de compartir a facebook.
